### PR TITLE
Use `relative="editor"` for popup windows to ensure full screen size

### DIFF
--- a/lua/fzf-lua-grep-context/picker/ui/layout.lua
+++ b/lua/fzf-lua-grep-context/picker/ui/layout.lua
@@ -53,6 +53,7 @@ function M.init()
   -- Combine input and list into a vertical layout
   layout = Layout(
     {
+      relative = "editor", -- use editor-relative positioning for fullscreen popups
       position = {
         row = winopts.row,
         col = winopts.col,


### PR DESCRIPTION
- Change popup and layout windows to use `relative="editor"`  
- Fixes issue where popups appeared half-sized after window splits  
- Ensures consistent full screen display regardless of split state