### PR TITLE
Function `border` handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,10 +117,10 @@ Expand to see the list of all the default options below.
       { "G", function() require("fzf-lua-grep-context.actions").move_bottom() end, mode = "n" },
       { "q", function() require("fzf-lua-grep-context.actions").exit() end, mode = "n" },
     },
-  },
-  checkbox = {
-    mark = "x",
-    hl = { fg = "#3CB371" },
+    checkbox = {
+      mark = "x",
+      hl = { fg = "#3CB371" },
+    },
   },
 }
 ```

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Expand to see the list of all the default options below.
 
 ```lua
 {
+  border = "rounded", -- Border style for the picker window
   contexts = {
     default = {
       title = "Default",
@@ -283,6 +284,18 @@ fn_transform_cmd = function(query, cmd, _)
   vim.opt.rtp:append(vim.env.FZF_LUA_GREP_CONTEXT)
   return require("fzf-lua-grep-context.transform").git_grep(query, cmd)
 end
+```
+
+### 🎨 Border Option
+
+The plugin introduces a `border` option to handle cases when `fzf-lua` profiles (e.g., `border-fused`) return a **function** instead of a value that [`nui.nvim`](https://github.com/MunifTanjim/nui.nvim) accepts.
+
+By default, the fallback border style is `"rounded"`.<br />
+Accepted values are the same as `nui.nvim` border styles (<https://github.com/MunifTanjim/nui.nvim/tree/main/lua/nui/popup#borderstyle>).<br />
+You can override this with your own preference:
+
+```lua
+border = "single", -- fallback if fzf-lua provides a function
 ```
 
 ## 🩺 Troubleshooting

--- a/lua/fzf-lua-grep-context/config.lua
+++ b/lua/fzf-lua-grep-context/config.lua
@@ -1,4 +1,5 @@
 -- Handles plugin configuration and context initialization
+local border = require("fzf-lua-grep-context.picker.ui.border")
 local contexts = require("fzf-lua-grep-context.contexts")
 local picker = require("fzf-lua-grep-context.picker")
 local transform = require("fzf-lua-grep-context.transform")
@@ -9,6 +10,7 @@ local util = require("fzf-lua-grep-context.util")
 
 ---User plugin options passed to setup()
 ---@class FzfLuaGrepContextOptions
+---@field border? nui_popup_border_option_style
 ---@field contexts? ContextGroups | ContextGroup
 ---@field picker? PickerOptions
 
@@ -64,6 +66,8 @@ function M.setup(opts)
 
   -- Set plugin root path for access from headless child processes
   vim.env.FZF_LUA_GREP_CONTEXT = util.get_plugin_root()
+
+  border.init(opts.border)
 
   -- Initialize all available context groups
   contexts.initialize_contexts(opts.contexts)

--- a/lua/fzf-lua-grep-context/picker/ui/border.lua
+++ b/lua/fzf-lua-grep-context/picker/ui/border.lua
@@ -1,0 +1,37 @@
+-- Border handling for fzf-lua-grep-context
+-- Ensure compatibility with nui.nvim by falling back when fzf-lua profile border returns a function
+
+local border = {
+  ---Default border style (fallback if fzf-lua provides a function)
+  ---@type nui_popup_border_option_style
+  style = "rounded",
+}
+
+---Initialize the border style (user-configurable).
+---@param style nui_popup_border_option_style?
+function border.init(style)
+  border.style = style or border.style
+end
+
+---Resolve fzf-lua border to a nui-compatible border style.
+---Note: "none" and "shadow" styles do not support border text.
+---@param fzf_lua_border nui_popup_border_option_style | function
+---@param text? nui_popup_border_option_text
+---@return nui_popup_border_options
+function border.resolve(fzf_lua_border, text)
+  local options = {} ---@class nui_popup_border_options
+
+  if type(fzf_lua_border) == "string" or type(fzf_lua_border) == "table" then
+    options.style = fzf_lua_border
+  else
+    options.style = border.style
+  end
+
+  if not (type(options.style) == "string" and (options.style == "none" or options.style == "shadow")) then
+    options.text = text
+  end
+
+  return options
+end
+
+return border

--- a/lua/fzf-lua-grep-context/picker/ui/layout.lua
+++ b/lua/fzf-lua-grep-context/picker/ui/layout.lua
@@ -3,6 +3,7 @@ local Input = require("nui.input")
 local Layout = require("nui.layout")
 local NuiText = require("nui.text")
 local Popup = require("nui.popup")
+local border = require("fzf-lua-grep-context.picker.ui.border")
 local filetype = require("fzf-lua-grep-context.filetype")
 local picker_state = require("fzf-lua-grep-context.picker.state")
 local state = require("fzf-lua-grep-context.picker.ui.state")
@@ -23,13 +24,10 @@ function M.init()
 
   -- Setup input popup window with live filtering callback
   input_popup = Input({
-    border = {
-      style = winopts.border,
-      text = {
-        top = picker_state.title,
-        top_align = winopts.title_pos,
-      },
-    },
+    border = border.resolve(winopts.border, {
+      top = picker_state.title,
+      top_align = winopts.title_pos,
+    }),
     win_options = {
       winhighlight = "Normal:FzfLuaNormal,FloatBorder:FzfLuaBorder,FloatTitle:FzfLuaTitle",
     },
@@ -44,7 +42,7 @@ function M.init()
 
   -- Setup list popup window
   list_popup = Popup({
-    border = { style = winopts.border },
+    border = border.resolve(winopts.border),
     win_options = {
       winhighlight = "Normal:FzfLuaNormal,FloatBorder:FzfLuaBorder,FloatTitle:FzfLuaTitle",
     },


### PR DESCRIPTION
Add `border` option to handle cases when `fzf-lua` profiles (e.g., `border-fused`) return a function instead of a value that `nui.nvim` accepts.
If `fzf-lua` profiles return a function, fallback to the `border` option value.
By default, the `border` option value is `"rounded"`.